### PR TITLE
Manifest V3に対応

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,4 @@
 {
-  "background": {
-  "page": "src/background.html"
-  },
   "options_page": "src/options.html",
   "action": {
     "default_icon": "img/favicon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "page": "src/background.html"
   },
   "options_page": "src/options.html",
-  "browser_action": {
+  "action": {
     "default_icon": "img/favicon.png",
     "default_title": "URL and Title Copier",
     "default_popup": "src/popup.html"

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,6 @@
   "permissions": [
     "tabs"
   ],
-  "version": "0.3.5",
-  "manifest_version": 2
+  "version": "0.4.0",
+  "manifest_version": 3
 }

--- a/src/copy.js
+++ b/src/copy.js
@@ -22,21 +22,24 @@ function getSeps() {
 }
 
 function copyTitle() {
-	chrome.tabs.getSelected(this.jstdata, function(tab) {
+	let queryOptions = {active: true, lastFocusedWindow: true};
+	chrome.tabs.query(queryOptions, ([tab]) => {
 		copyToClipboard( tab.title );
 		window.close();
 	});
 }
 
 function copyurl() {
-	chrome.tabs.getSelected(this.jstdata, function(tab) {
+	let queryOptions = {active: true, lastFocusedWindow: true};
+	chrome.tabs.query(queryOptions, ([tab]) => {
 	  copyToClipboard( tab.url );
 	  window.close();
 	});
 }
 
 function copyurlAsMarkdown() {
-	chrome.tabs.getSelected(this.jstdata, function(tab) {
+	let queryOptions = {active: true, lastFocusedWindow: true};
+	chrome.tabs.query(queryOptions, ([tab]) => {
 	  if( tab.title ){
 	    copyToClipboard('['+tab.title+']'+'('+tab.url+')');
 	  } else {
@@ -47,7 +50,8 @@ function copyurlAsMarkdown() {
 }
 
 function copytitleurl() {
-	chrome.tabs.getSelected(this.jstdata, function(tab) {
+	let queryOptions = {active: true, lastFocusedWindow: true};
+	chrome.tabs.query(queryOptions, ([tab]) => {
 	  if( tab.title ){
 	    copyToClipboard( tab.title + getSeps() + tab.url );
 	  } else {
@@ -58,7 +62,8 @@ function copytitleurl() {
 }
 
 function copytitleurlWithGt() {
-	chrome.tabs.getSelected(this.jstdata, function(tab) {
+	let queryOptions = {active: true, lastFocusedWindow: true};
+	chrome.tabs.query(queryOptions, ([tab]) => {
 		if( tab.title ){
 			copyToClipboard( "> " + tab.title + getSeps() + "> " + tab.url );
 		} else {
@@ -69,7 +74,8 @@ function copytitleurlWithGt() {
 }
 
 function copyurlwtag() {
-	chrome.tabs.getSelected(this.jstdata,function(tab) {
+	let queryOptions = {active: true, lastFocusedWindow: true};
+	chrome.tabs.query(queryOptions, ([tab]) => {
 	  if( tab.title ){
 	    copyToClipboard( "<a href=\"" + tab.url + "\">" + tab.title + "</a>" );
 	  } else {


### PR DESCRIPTION
Chrome ExtensionのManifest V3に対応しました。

**変更箇所**
- browser_actionをactionに置き換え
- chrome.tabs.getSelected()をchrome.tabs.query()に置き換え
- Manifestからbackgroundを削除
- 拡張機能のアイコンを更新